### PR TITLE
Refactor layout, text contrast and update prize pool details

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,25 +47,25 @@ export default function HomePage() {
         </div>
 
         {/* Competition Details */}
-        <div className="grid md:grid-cols-3 gap-8 mb-20">
-          <div className="flex flex-col items-center text-center">
-            <Calendar className="w-12 h-12 text-white/70 mb-4" />
+        <div className="grid md:grid-cols-3 gap-8 mb-20 max-w-6xl mx-auto">
+          <div className="flex flex-col items-center text-center bg-gray-400/5 border border-white/10 rounded-xl p-5">
+            <Calendar className="w-10 h-10 text-white/70 mb-4" />
             <h3 className="text-white text-2xl font-medium mb-2">1 Week</h3>
             <p className="text-white/50">
               Complete your clone within the competition timeframe
             </p>
           </div>
 
-          <div className="flex flex-col items-center text-center">
-            <Trophy className="w-12 h-12 text-white/70 mb-4" />
+          <div className="flex flex-col items-center text-center bg-gray-400/5 border border-white/10 rounded-xl p-5">
+            <Trophy className="w-10 h-10 text-white/70 mb-4" />
             <h3 className="text-white text-2xl font-medium mb-2">$10,000+</h3>
             <p className="text-white/50">
               Total prize pool for winners and participants
             </p>
           </div>
 
-          <div className="flex flex-col items-center text-center">
-            <Code className="w-12 h-12 text-white/70 mb-4" />
+          <div className="flex flex-col items-center text-center bg-gray-400/5 border border-white/10 rounded-xl p-5">
+            <Code className="w-10 h-10 text-white/70 mb-4" />
             <h3 className="text-white text-2xl font-medium mb-2">
               Open Source
             </h3>
@@ -354,40 +354,44 @@ export default function HomePage() {
             <div className="space-y-6">
               <div className="flex items-start gap-3">
                 <CheckCircle className="w-5 h-5 text-white/70 mt-1 flex-shrink-0" />
-                <p className="text-white/90">
-                  <strong>Open Source Requirement:</strong> Submissions must be
-                  open source with a permissive license (MIT, Apache, BSD etc.)
-                  and hosted on GitHub
+                <p className="text-white/70">
+                  <strong className="text-white/90">
+                    Open Source Requirement:
+                  </strong>{" "}
+                  Submissions must be open source with a permissive license
+                  (MIT, Apache, BSD etc.) and hosted on GitHub
                 </p>
               </div>
 
               <div className="flex items-start gap-3">
                 <CheckCircle className="w-5 h-5 text-white/70 mt-1 flex-shrink-0" />
-                <p className="text-white/90">
-                  <strong>Age Requirement:</strong> Must be 18+ to be eligible
-                  for prizes
+                <p className="text-white/70">
+                  <strong className="text-white/90">Age Requirement:</strong>{" "}
+                  Must be 18+ to be eligible for prizes
                 </p>
               </div>
 
               <div className="flex items-start gap-3">
                 <CheckCircle className="w-5 h-5 text-white/70 mt-1 flex-shrink-0" />
-                <p className="text-white/90">
-                  <strong>Team Size:</strong> No more than 4 people per team
+                <p className="text-white/70">
+                  <strong className="text-white/90">Team Size:</strong> No more
+                  than 4 people per team
                 </p>
               </div>
 
               <div className="flex items-start gap-3">
                 <CheckCircle className="w-5 h-5 text-white/70 mt-1 flex-shrink-0" />
-                <p className="text-white/90">
-                  <strong>Code of Conduct:</strong> Don't harass anyone please
+                <p className="text-white/70">
+                  <strong className="text-white/90">Code of Conduct:</strong>{" "}
+                  Don't harass anyone please
                 </p>
               </div>
 
               <div className="flex items-start gap-3">
                 <CheckCircle className="w-5 h-5 text-white/70 mt-1 flex-shrink-0" />
-                <p className="text-white/90">
-                  <strong>Content Usage:</strong> Theo might use your submission
-                  for content btw
+                <p className="text-white/70">
+                  <strong className="text-white/90">Content Usage:</strong> Theo
+                  might use your submission for content btw
                 </p>
               </div>
             </div>

--- a/app/terms-and-conditions/page.tsx
+++ b/app/terms-and-conditions/page.tsx
@@ -84,11 +84,11 @@ export default function TermsAndConditionsPage() {
               </ul>
             </li>
             <li>
-              Prizes: total cash pool of [​$6500​], distributed as follows:
+              Prizes: total cash pool of [​$8000] (excluding t3.chat subscription price), distributed as follows:
               <ul>
                 <li>1st Place: [​$5000​]</li>
-                <li>2nd Place: [​$1000​]</li>
-                <li>3rd Place: [​$500​]</li>
+                <li>2nd Place: [​$2000​]</li>
+                <li>3rd Place: [​$1000​]</li>
               </ul>
             </li>
             <li>Winners will be announced no later than June 30, 2025.</li>

--- a/components/countdown-timer.tsx
+++ b/components/countdown-timer.tsx
@@ -67,6 +67,14 @@ export function CountdownTimer() {
     return () => clearInterval(timer);
   }, []);
 
+  if (isExpired) {
+    return (
+      <div className="text-center text-white/50 text-sm border-2 border-white/30 p-3 rounded-xl w-fit mx-auto">
+        Competition ended
+      </div>
+    );
+  }
+
   if (!isMounted) {
     return (
       <div className="text-center">
@@ -92,12 +100,6 @@ export function CountdownTimer() {
           Deadline: June 17, 2025 at 12:00 PM PDT
         </div>
       </div>
-    );
-  }
-
-  if (isExpired) {
-    return (
-      <div className="text-center text-white/50 text-sm">Competition ended</div>
     );
   }
 
@@ -129,7 +131,7 @@ export function CountdownTimer() {
           <div className="text-xs text-white/40 mt-1 font-medium">sec</div>
         </div>
       </div>
-      <div className="text-xs text-white/40 mt-3 animate-in fade-in duration-500">
+      <div className="text-xs text-white/60 mt-3 animate-in fade-in duration-500">
         Deadline: June 17, 2025 at 12:00 PM PDT
       </div>
     </div>


### PR DESCRIPTION
- Add max width in competition details and change contrast. [ Fixes #2 ]
  <img src="https://github.com/user-attachments/assets/bffccf3e-981d-4667-9016-5d9bdcfddc40" height=300/> 
  <img src="https://github.com/user-attachments/assets/b6ef4e0a-b7e6-40af-b115-b595a88df646" height=300/> 

- Check for expired competition first to reduce layout shift
- Update the prize pool details in TOS. ( The home page's prizes are taken as the main one ) [ Fixes #1 ]
  <img src="https://github.com/user-attachments/assets/0f4c3de6-dd2d-473b-b466-6f1c07ab28d9" width=500/> 



I'm not sure about the prize pool details. So, you may change that if needed.